### PR TITLE
Slot Error evaluation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ The **act types used** in this dataset are:
 * `goodbye` -- goodbye
 
 **Slots used** in this dataset are:
-* `name` -- restaurant name* `count` -- number of restaurants matching criteria
+* `name` -- restaurant name
+* `count` -- number of restaurants matching criteria
 * `type` -- venue type (the only value used here is `restaurant`)
 * `price_range` -- restaurant price range (`cheap`, `moderate`, `expensive`)
 * `price` -- the actual meal price (or price range) in Czech Crowns (Kč)
@@ -111,6 +112,30 @@ The **act types used** in this dataset are:
 * `food` -- food type, i.e., cuisine (`Chinese`, `French`, etc.)
 * `good_for_meal` -- suitability for a particular meal (`breakfast`, `lunch`, `brunch`, `dinner`)
 * `kids_allowed` -- suitability for children
+
+Slot Error Rate evaluation
+--------------------------
+
+Additionally we provide an evaluation script for further research purposes. The script `measure_slot_error_rate.py` computes the Slot Error Rate defined as:
+
+  SER = (# missing slots + # additional slots) / # total number of slots
+
+This is done by comparing the slot values in each input dialogue acts with provided dialogue system output. Note that this script was created after publishing the corresponding paper and the scores **do not** correspond to those in the paper. Most significatly, the script is able to check the `kids_allowed` slot, which was not handled in the original paper.
+
+### Usage ###
+
+To evaluate your NLG system output `output.txt` on the test set run the following command:
+
+```
+python measure_slot_error_rate.py --sys_file output.txt surface_forms.json test.csv
+```
+
+See the list of found errors by increasing the verbosity of the script by adding the `-vv` argument.
+
+For detailed usage information run:
+```
+python measure_slot_error_rate.py -h
+```
 
 Acknowledgments
 ---------------

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The **act types used** in this dataset are:
 * `goodbye` -- goodbye
 
 **Slots used** in this dataset are:
-* `name` -- restaurant name
+* `name` -- restaurant name* `count` -- number of restaurants matching criteria
 * `type` -- venue type (the only value used here is `restaurant`)
 * `price_range` -- restaurant price range (`cheap`, `moderate`, `expensive`)
 * `price` -- the actual meal price (or price range) in Czech Crowns (Kč)

--- a/measure_slot_error_rate.py
+++ b/measure_slot_error_rate.py
@@ -338,13 +338,23 @@ def evaluate(surface_forms, das, sys):
 
 
 if __name__ == '__main__':
-    logging.getLogger().setLevel(logging.DEBUG)
+    
 
     ap = ArgumentParser(description='Slot Error Rate evaluation for Czech restaurant information dataset')
     ap.add_argument('surface_forms_file', type=str, help='JSON file containing the surface forms for all slot values.')
     ap.add_argument('ref_file', type=str, help='References CSV file containing the dialogue acts (DAs) in the first column.')
     ap.add_argument('--sys_file', type=str, help='System output file to evaluate (text file with one output per line).')
+    ap.add_argument('-v', '--verbosity', action="count", help="increase output verbosity (e.g., -vv is more than -v)")
     args = ap.parse_args()
+
+    if args.verbosity == 3:
+        logging.getLogger().setLevel(logging.DEBUG)
+    if args.verbosity == 2:
+        logging.getLogger().setLevel(logging.INFO)
+    if args.verbosity == 1:
+        logging.getLogger().setLevel(logging.WARNING)
+    if args.verbosity == 0:
+        logging.getLogger().setLevel(logging.ERROR)
 
     surface_forms, das, sys = load_data(args.surface_forms_file, args.ref_file, args.sys_file)
 

--- a/measure_slot_error_rate.py
+++ b/measure_slot_error_rate.py
@@ -252,6 +252,8 @@ class Evaluator:
                 # but cannot contain negation before/after kids
                 is_valid = match_kids_slot and not match_kids_negation
                 self.count_slot_missing_error(is_valid)
+                if is_valid:
+                    sys_line = self.remove_from_sentence(sys_line, match_kids_slot)
                 self.log_slot_missing_error(is_valid, value, slot, sys_line_orig, index)
             elif value == "no":
                 match_kids_negation = self.find_kids_negation(sys_line, negation_max_word_distance)
@@ -259,6 +261,8 @@ class Evaluator:
                 # and must contain negation before/after kids
                 is_valid = match_kids_slot and match_kids_negation
                 self.count_slot_missing_error(is_valid)
+                if is_valid:
+                    sys_line = self.remove_from_sentence(sys_line, match_kids_slot)
                 sys_line = self.remove_from_sentence(sys_line, match_kids_negation)
                 self.log_slot_missing_error(is_valid, value, slot, sys_line_orig, index)
             elif value == "dont_care":
@@ -408,7 +412,7 @@ class Evaluator:
 
             # Find additional kids_allowed slot
             match_kids_slot = self.surface_forms_match(sys_line, self.kids_surface_forms)
-            if match_kids_slot and "kids_allowed" not in attributes:
+            if match_kids_slot and ("kids_allowed" not in attributes or attributes["kids_allowed"] in [["yes"], ["no"]]):
                 self.log_additional_slot_error(match_kids_slot, "kids_allowed", sys_line_orig, da_line, index)
                 self.num_additional_slot_value_error += 1
 

--- a/measure_slot_error_rate.py
+++ b/measure_slot_error_rate.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 from argparse import ArgumentParser
 import csv
@@ -24,6 +23,8 @@ def read_csv(csv_file):
         return fields
 
 def load_data(surface_forms_file, ref_file, sys_file):
+    """Loads the data using helper functions. 
+    For ref_file it loads it in correct format according to its extension"""
     surface_forms = read_json(surface_forms_file)
 
     ref_file_ext = os.path.splitext(ref_file)[1]
@@ -43,9 +44,18 @@ def load_data(surface_forms_file, ref_file, sys_file):
     return surface_forms, das, sys
 
 def parse_da(da):
-    '''
-    Parses one line of Dialogue Act in the form of "DA_TYPE(SLOT=VALUE,...)".
-    '''
+    """Parses one line of Dialogue Act in the form of "DA_TYPE(SLOT=VALUE,...)".
+
+    Args:
+        da (str): one dialogue act string
+
+    Returns:
+        dict: a dictionary containing the parsed information from the input DA string.
+
+    Example:
+        >>> parse_da("inform(good_for_meal='lunch or dinner',name=BarBar)")
+        {'type': 'inform', 'attributes': {'good_for_meal': ['lunch', 'dinner'], 'name': ['BarBar']}}
+    """
 
     # Each DA string has exactly one set of parentheses,
     # they contain the attributes of the da_type (or contain nothing)
@@ -113,24 +123,45 @@ def test_parse_da():
         "type": "?request",
         "attributes": {"rr": ["Baráčnická Rychta", "dont_care"], "cc": ["382"]}
     }
-test_parse_da()
 
-def evaluate(surface_forms, das, sys):
-    def exact_match(sentence, value):
-        value = str(value)
-        if value in sentence:
-            return value
+class Evaluator:
+    """Main class for running the Slot Error Rate evaluation"""
+
+    def __init__(self, surface_forms):
+        # Main counters for the resulting SER
+        self.num_valid_slot_values = 0
+        self.num_missing_slot_value_error = 0
+        self.num_additional_slot_value_error = 0
+
+        # Counter for checking the coverage of this evaluator
+        self.num_cannot_check_slot_values = 0
+
+        # Remove the lemma and tags in the surface forms
+        self.surface_forms = {slot: {lemma: [form.split("\t")[1] for form in forms] for lemma, forms in values.items()} for slot, values in surface_forms.items()}
+        self.kids_surface_forms = ["děti", "dětí", "dětem", "dětmi"]
+        self.price_surface_forms = self.surface_forms["price"]["between _ and _ Kč"]
+
+    def exact_match(self, sentence, substring):
+        """Search for substring in sentence, if there is match return it.
+        If not, return False."""
+        substring = str(substring)
+        if substring in sentence:
+            return substring
         else:
             return False
     
-    def regex_match(sentence, regex, group=0):
+    def regex_match(self, sentence, regex, group=0):
+        """Search for regex match in sentence, if there is match return it.
+        If not, return False."""
         matches = re.search(regex, sentence, re.IGNORECASE)
         if matches:
             return matches.group(group)
         else:
             return False
 
-    def address_match(street_value, sentence, forms):
+    def address_match(self, street_value, sentence, forms):
+        """Search for address of form "Street Name 123" in sentence,
+        if there is match return it. If not, return False."""
         street_name, street_num = street_value.rsplit(" ", 1)
         if street_name in forms:
             for test_name in forms[street_name]:
@@ -139,7 +170,9 @@ def evaluate(surface_forms, das, sys):
                     return test_address
         return False
 
-    def surface_forms_match(sentence, forms):
+    def surface_forms_match(self, sentence, forms):
+        """Search for all forms (and capitalized variants) of a word in a sentence, 
+        if there is match return it. If not, return False."""
         # We look for some variations in capitalization
         capitalized_first_letters = [form.title() for form in forms]
         forms = set(forms + capitalized_first_letters)
@@ -159,239 +192,253 @@ def evaluate(surface_forms, das, sys):
 
         return False
 
-    def remove_from_sentence(sentence, value):
-        if value:
-            new_sentence = "".join(sentence.split(value))
+    def remove_from_sentence(self, sentence, substring):
+        """Remove a substring from a sentence. Deduplicates whitespaces."""
+        if substring:
+            new_sentence = "".join(sentence.split(substring))
             # Replace multiple spaces with one
             new_sentence = re.sub(' +',' ',new_sentence)
-            assert new_sentence != sentence, f"didn't find match for value {value} in sentence {sentence}"
+            assert new_sentence != sentence, f"didn't find match for substring {substring} in sentence {sentence}"
             return new_sentence
         else:
             return sentence
     
-    def find_kids_negation(sys_line, negation_max_word_distance):
+    def find_kids_negation(self, sys_line, negation_max_word_distance):
+        """Looks for a word combination indicating kids_allowed=no in the input sentence"""
         negation_max_word_distance = str(negation_max_word_distance)
-        match = regex_match(sys_line, r"\b(ne\w*) (?:\w+ ){0,"+negation_max_word_distance+r"}dět\w*", group=1)
+        match = self.regex_match(sys_line, r"\b(ne\w*) (?:\w+ ){0,"+negation_max_word_distance+r"}dět\w*", group=1)
         if not match:
             # (?!a ) is there because of "... a ..." conjunction
-            match = regex_match(sys_line, r"dět\w* (?!a )(?:\w+ ){0,2}(ne\w+)", group=1)
+            match = self.regex_match(sys_line, r"dět\w* (?!a )(?:\w+ ){0,2}(ne\w+)", group=1)
         if not match:
-            match = regex_match(sys_line, r"(zakáz\w*|zákaz\w*) (?:\w+ ){0,"+negation_max_word_distance+r"}dět\w*", group=1)
+            match = self.regex_match(sys_line, r"(zakáz\w*|zákaz\w*) (?:\w+ ){0,"+negation_max_word_distance+r"}dět\w*", group=1)
         if not match:
-            match = regex_match(sys_line, r"dět\w* (?:\w+ ){0,"+negation_max_word_distance+r"}(zakáz\w*|zákaz\w*)", group=1)
+            match = self.regex_match(sys_line, r"dět\w* (?:\w+ ){0,"+negation_max_word_distance+r"}(zakáz\w*|zákaz\w*)", group=1)
         if not match:
-            match = regex_match(sys_line, r"(bez) (?:\w+ ){0,3}dět\w*", group=1)
+            match = self.regex_match(sys_line, r"(bez) (?:\w+ ){0,3}dět\w*", group=1)
         return match
     
-    def count_slot_missing_error(is_valid):
-        nonlocal num_valid_slot_values, num_missing_slot_value_error
-        num_valid_slot_values += 1
+    def count_slot_missing_error(self, is_valid):
+        """Adds to the total number of slot values and possibly to the number of errors"""
+        self.num_valid_slot_values += 1
         if not is_valid:
-            num_missing_slot_value_error += 1
+            self.num_missing_slot_value_error += 1
     
-    def log_slot_missing_error(is_valid, value, slot, sys_line, index):
+    def log_slot_missing_error(self, is_valid, value, slot, sys_line, index):
         if not is_valid:
             logging.info(f"Slot Error: didn't find match for '{value}' for slot '{slot}' in instance {index}: '{sys_line}'")
     
-    def log_additional_slot_error(substring, slot, sys_line, da_line, index):
+    def log_additional_slot_error(self, substring, slot, sys_line, da_line, index):
         logging.info(f"Slot Error: found substring '{substring}' implying slot '{slot}' in instance {index}: '{sys_line}'. DA is '{da_line}'")
 
+    def handle_kids_allowed(self, values, sys_line, da, slot, sys_line_orig, index):
+        """Subroutine for the evaluate function, checks the kids_allowed slot"""
+        match_kids_slot = self.surface_forms_match(sys_line, self.kids_surface_forms)
 
-    surface_forms = {slot: {lemma: [form.split("\t")[1] for form in forms] for lemma, forms in values.items()} for slot, values in surface_forms.items()}
-    num_cannot_check_slot_values = 0
-    num_total_num_of_slot_values = 0
-    num_type_slots = 0
+        # For two examples in the train set the value is missing but =yes is assumed
+        if len(values) == 0:
+            values = ["yes"]
 
-    num_valid_slot_values = 0
-    num_missing_slot_value_error = 0
-    num_additional_slot_value_error = 0
-
-    for index, (da_line, sys_line_orig) in enumerate(zip(das, sys)):
-        sys_line = sys_line_orig
-        da = parse_da(da_line)
-        attributes = da["attributes"]
-
-        num_total_num_of_slot_values += sum(len(values) for _, values in attributes.items())
-        # we count the empty slots as one value
-        num_total_num_of_slot_values += sum(len(values) == 0 for _, values in attributes.items())
-
-        attribute_priorities = {
-            "kids_allowed": 10
-        }
-        attribute_list = [(slot, values, attribute_priorities[slot] if slot in attribute_priorities else 99) for slot, values in attributes.items()]
-        attribute_list = sorted(attribute_list, key=lambda x: x[2])
-        for slot, values, _ in attribute_list:
-            # We cannot handle slots with no values, we log the number of these unhandled cases
-            # The only slot that we can handle with no value is the kids_allowed
-            if slot != "kids_allowed" and values == []:
-                # we count missing values as one slot value
-                num_cannot_check_slot_values += 1
-                logging.debug(f"Coverage problem: We cannot handle {slot} with no value.")
-                continue
-            
-            # Big switch statement for handling different slot types
-            if slot == "type":
-                num_type_slots += 1
-                num_cannot_check_slot_values += 1
-                # We don't log the coverage problem here because we don't have to check this slot
-                continue
-            elif slot == "kids_allowed":
-                match_kids_slot = surface_forms_match(sys_line, ["děti", "dětí", "dětem", "dětmi"])
-
-                # For two examples in the train set the value is missing but =yes is assumed
-                if len(values) == 0:
-                    values = ["yes"]
-
-                if len(values) == 1:
-                    value = values[0]
-                    negation_max_word_distance = 5
-                    # inform_no_match will very probably contain a negation
-                    # therefore we need to check smaller neighbourhood around "děti"
-                    if da["type"] == "inform_no_match":
-                        negation_max_word_distance = 3
-                    if value == "yes":
-                        match_kids_negation = find_kids_negation(sys_line, negation_max_word_distance)
-                        # the sentence needs to contain the word kids
-                        # but cannot contain negation before/after kids
-                        is_valid = match_kids_slot and not match_kids_negation
-                        count_slot_missing_error(is_valid)
-                        log_slot_missing_error(is_valid, value, slot, sys_line_orig, index)
-                    elif value == "no":
-                        match_kids_negation = find_kids_negation(sys_line, negation_max_word_distance)
-                        # the sentence needs to contain the word kids
-                        # and must contain negation before/after kids
-                        is_valid = match_kids_slot and match_kids_negation
-                        count_slot_missing_error(is_valid)
-                        sys_line = remove_from_sentence(sys_line, match_kids_negation)
-                        log_slot_missing_error(is_valid, value, slot, sys_line_orig, index)
-                    elif value == "dont_care":
-                        num_cannot_check_slot_values += 1
-                        logging.debug(f"Coverage problem: We cannot handle kids_allowed='dont_care'")
-                    elif value == "none":
-                        num_cannot_check_slot_values += 1
-                        logging.debug(f"Coverage problem: We cannot handle kids_allowed='none'")
-                    else:
-                        assert False, f"Invalid value {value} for kids_allowed"
-
-                if len(values) == 2:
-                    if set(values) == {"yes", "no"}:
-                        num_cannot_check_slot_values += 2
-                        logging.debug(f"Coverage problem: We cannot handle kids_allowed='yes or no'")
-                    elif set(values) == {"dont_care", "yes"}:
-                        num_cannot_check_slot_values += 2
-                        logging.debug(f"Coverage problem: We cannot handle kids_allowed='yes',kids_allowed='dont_care'")
-                    else:
-                        assert False, f"Invalid value {values} for kids_allowed"
-
-            elif slot in ["phone", "count", "postcode"]:
-                # TODO: For count we might want to implement checking numerals (such as "dvě", "tři", ...)
-                for value in values:
-                    match = exact_match(sys_line, value)
-                    count_slot_missing_error(match)
-                    sys_line = remove_from_sentence(sys_line, match)
-                    log_slot_missing_error(match, value, slot, sys_line_orig, index)
-            elif slot == "address":
-                for value in values:
-                    match = address_match(value, sys_line, surface_forms["street"])
-                    count_slot_missing_error(match)
-                    sys_line = remove_from_sentence(sys_line, match)
-                    log_slot_missing_error(match, value, slot, sys_line_orig, index)
-            elif slot == "price":
-                for value in values:
-                    if "between" in value:
-                        # remove text around prices
-                        value = value[8:-3]
-                        price1, price2 = value.split(" and ")
-                        match = False
-                        for form in surface_forms["price"]["between _ and _ Kč"]:
-                            form = form.split("_")
-                            assert len(form) == 3
-                            czech_between_string = form[0] + price1 + form[1] + price2 + form[2]
-                            match = exact_match(sys_line, czech_between_string)
-                            if match:
-                                break
-                    else:
-                        match = exact_match(sys_line, value)
-                    
-                    count_slot_missing_error(match)
-                    sys_line = remove_from_sentence(sys_line, match)
-                    log_slot_missing_error(match, value, slot, sys_line_orig, index)
-            elif slot in surface_forms:
-                for value in values:
-                    if value in surface_forms[slot]:
-                        match = surface_forms_match(sys_line, surface_forms[slot][value])
-                        count_slot_missing_error(match)
-                        sys_line = remove_from_sentence(sys_line, match)
-                        log_slot_missing_error(match, value, slot, sys_line_orig, index)
-                    else:
-                        # TODO: handle dont_care
-                        if value == "dont_care":
-                            num_cannot_check_slot_values += 1
-                            logging.debug(f"Coverage problem: We cannot handle value 'dont_care' for slot {slot}")
-                        # TODO: handle none
-                        if value == "none":
-                            num_cannot_check_slot_values += 1
-                            logging.debug(f"Coverage problem: We cannot handle value 'none' for slot {slot}")
+        if len(values) == 1:
+            value = values[0]
+            negation_max_word_distance = 5
+            # inform_no_match will very probably contain a negation
+            # therefore we need to check smaller neighbourhood around "děti"
+            if da["type"] == "inform_no_match":
+                negation_max_word_distance = 3
+            if value == "yes":
+                match_kids_negation = self.find_kids_negation(sys_line, negation_max_word_distance)
+                # the sentence needs to contain the word kids
+                # but cannot contain negation before/after kids
+                is_valid = match_kids_slot and not match_kids_negation
+                self.count_slot_missing_error(is_valid)
+                self.log_slot_missing_error(is_valid, value, slot, sys_line_orig, index)
+            elif value == "no":
+                match_kids_negation = self.find_kids_negation(sys_line, negation_max_word_distance)
+                # the sentence needs to contain the word kids
+                # and must contain negation before/after kids
+                is_valid = match_kids_slot and match_kids_negation
+                self.count_slot_missing_error(is_valid)
+                sys_line = self.remove_from_sentence(sys_line, match_kids_negation)
+                self.log_slot_missing_error(is_valid, value, slot, sys_line_orig, index)
+            elif value == "dont_care":
+                self.num_cannot_check_slot_values += 1
+                logging.debug(f"Coverage problem: We cannot handle kids_allowed='dont_care'")
+            elif value == "none":
+                self.num_cannot_check_slot_values += 1
+                logging.debug(f"Coverage problem: We cannot handle kids_allowed='none'")
             else:
-                logging.error(f"Invalid slot in the parsed attributes of DA '{da_line}': {slot}")
-                pass
+                assert False, f"Invalid value {value} for kids_allowed"
+
+        if len(values) == 2:
+            if set(values) == {"yes", "no"}:
+                self.num_cannot_check_slot_values += 2
+                logging.debug(f"Coverage problem: We cannot handle kids_allowed='yes or no'")
+            elif set(values) == {"dont_care", "yes"}:
+                self.num_cannot_check_slot_values += 2
+                logging.debug(f"Coverage problem: We cannot handle kids_allowed='yes',kids_allowed='dont_care'")
+            else:
+                assert False, f"Invalid value {values} for kids_allowed"
         
-        
-        # Find additional slot values that are not supposed to be in the system output
-        for surface_forms_slot in surface_forms:
+        return sys_line
 
-            # Do not check those slots that are inside the DA without any value
-            # These often list some or all of the value keywords to raise a question to the user
-            if surface_forms_slot in attributes and attributes[surface_forms_slot] == []:
-                continue
-            # Do not check the good_for_meal slot for DA goodbye().
-            # To avoid false additional error in sentences such as "Přeji dobrou chuť k večeři ."
-            if da["type"] == "goodbye" and surface_forms_slot == "good_for_meal":
-                continue
+    def handle_price(self, values, sys_line, da, slot, sys_line_orig, index):
+        """Subroutine for the evaluate function, checks the price slot"""
+        for value in values:
+            if "between" in value:
+                # remove text around prices
+                value = value[8:-3]
+                price1, price2 = value.split(" and ")
+                match = False
+                for _form in self.price_surface_forms:
+                    form = _form.split("_")
+                    assert len(form) == 3, _form
+                    czech_between_string = form[0] + price1 + form[1] + price2 + form[2]
+                    match = self.exact_match(sys_line, czech_between_string)
+                    if match:
+                        break
+            else:
+                match = self.exact_match(sys_line, value)
+            
+            self.count_slot_missing_error(match)
+            sys_line = self.remove_from_sentence(sys_line, match)
+            self.log_slot_missing_error(match, value, slot, sys_line_orig, index)
+        return sys_line
 
-            if surface_forms_slot == "price_range":
-                continue
-            for forms in surface_forms[surface_forms_slot].values():
-                match = surface_forms_match(sys_line, forms)
-                if match:
-                    log_additional_slot_error(match, surface_forms_slot, sys_line_orig, da_line, index)
-                    num_additional_slot_value_error += 1
-                    # print(sys_line, forms)
+    def evaluate(self, das, sys):
+        """Computes the Slot Error Rate.
 
-        # Find additional kids_allowed slot
-        match_kids_slot = surface_forms_match(sys_line, ["děti", "dětí", "dětem", "dětmi"])
-        if match_kids_slot and "kids_allowed" not in attributes:
-            log_additional_slot_error(match_kids_slot, "kids_allowed", sys_line_orig, da_line, index)
-            num_additional_slot_value_error += 1
+        Args:
+            das (List[str]): Dialogue Act lines
+            sys (List[str]): System output lines
+        """
+        self.num_cannot_check_slot_values = 0
+        num_total_num_of_slot_values = 0
+        num_type_slots = 0
 
-    logging.info(f"Total number of DAs: {len(das)}")
+        self.num_valid_slot_values = 0
+        self.num_missing_slot_value_error = 0
+        self.num_additional_slot_value_error = 0
 
-    diff_cannot_check = num_total_num_of_slot_values-num_valid_slot_values
-    assert num_cannot_check_slot_values == diff_cannot_check, "The number of slots we know we cannot check should equal the total number of slots and the number of slots that we correctly handled"
+        for index, (da_line, sys_line_orig) in enumerate(zip(das, sys)):
+            sys_line = sys_line_orig
+            da = parse_da(da_line)
+            attributes = da["attributes"]
 
-    logging.info(f"Total number of slots: {num_total_num_of_slot_values}")
-    logging.info(f"Slots that we cannot check: {num_cannot_check_slot_values}, out of which {num_type_slots} are 'type=restaurant' slots")
-    errors = num_missing_slot_value_error+num_additional_slot_value_error
-    print("Missing Slot Errors: ", num_missing_slot_value_error)
-    print("Additional Slot Errors: ", num_additional_slot_value_error)
-    print("Total Slot Errors: ", errors)
-    print("Number of slots checked: ", num_valid_slot_values)
-    if num_valid_slot_values:
-        SER = errors / num_valid_slot_values
-    else:
-        logging.warning(f"Didn't find any valid slots")
-        SER = 0
+            num_total_num_of_slot_values += sum(len(values) for _, values in attributes.items())
+            # we count the empty slots as one value
+            num_total_num_of_slot_values += sum(len(values) == 0 for _, values in attributes.items())
 
-    print("SER:", SER)
+            attribute_priorities = {
+                "kids_allowed": 10
+            }
+            attribute_list = [(slot, values, attribute_priorities[slot] if slot in attribute_priorities else 99) for slot, values in attributes.items()]
+            attribute_list = sorted(attribute_list, key=lambda x: x[2])
+            for slot, values, _ in attribute_list:
+                # We cannot handle slots with no values, we log the number of these unhandled cases
+                # The only slot that we can handle with no value is the kids_allowed
+                if slot != "kids_allowed" and values == []:
+                    # we count missing values as one slot value
+                    self.num_cannot_check_slot_values += 1
+                    logging.debug(f"Coverage problem: We cannot handle {slot} with no value.")
+                    continue
+                
+                # Big switch statement for handling different slot types
+                if slot == "type":
+                    num_type_slots += 1
+                    self.num_cannot_check_slot_values += 1
+                    # We don't log the coverage problem here because we don't have to check this slot
+                    continue
+                elif slot == "kids_allowed":
+                    sys_line = self.handle_kids_allowed(values, sys_line, da, slot, sys_line_orig, index)
+                elif slot in ["phone", "count", "postcode"]:
+                    # TODO: For count we might want to implement checking numerals (such as "dvě", "tři", ...)
+                    for value in values:
+                        match = self.exact_match(sys_line, value)
+                        self.count_slot_missing_error(match)
+                        sys_line = self.remove_from_sentence(sys_line, match)
+                        self.log_slot_missing_error(match, value, slot, sys_line_orig, index)
+                elif slot == "address":
+                    for value in values:
+                        match = self.address_match(value, sys_line, self.surface_forms["street"])
+                        self.count_slot_missing_error(match)
+                        sys_line = self.remove_from_sentence(sys_line, match)
+                        self.log_slot_missing_error(match, value, slot, sys_line_orig, index)
+                elif slot == "price":
+                    sys_line = self.handle_price(values, sys_line, da, slot, sys_line_orig, index)
+                elif slot in self.surface_forms:
+                    for value in values:
+                        if value in self.surface_forms[slot]:
+                            match = self.surface_forms_match(sys_line, self.surface_forms[slot][value])
+                            self.count_slot_missing_error(match)
+                            sys_line = self.remove_from_sentence(sys_line, match)
+                            self.log_slot_missing_error(match, value, slot, sys_line_orig, index)
+                        else:
+                            # TODO: handle dont_care
+                            if value == "dont_care":
+                                self.num_cannot_check_slot_values += 1
+                                logging.debug(f"Coverage problem: We cannot handle value 'dont_care' for slot {slot}")
+                            # TODO: handle none
+                            if value == "none":
+                                self.num_cannot_check_slot_values += 1
+                                logging.debug(f"Coverage problem: We cannot handle value 'none' for slot {slot}")
+                else:
+                    logging.error(f"Invalid slot in the parsed attributes of DA '{da_line}': {slot}")
+                    pass
+            
+            
+            # Find additional slot values that are not supposed to be in the system output
+            for surface_forms_slot, surface_forms_values in self.surface_forms.items():
+                # Do not check those slots that are inside the DA without any value
+                # These often list some or all of the value keywords to raise a question to the user
+                if surface_forms_slot in attributes and attributes[surface_forms_slot] == []:
+                    continue
+                # Do not check the good_for_meal slot for DA goodbye().
+                # To avoid false additional error in sentences such as "Přeji dobrou chuť k večeři ."
+                if da["type"] == "goodbye" and surface_forms_slot == "good_for_meal":
+                    continue
 
+                if surface_forms_slot == "price_range":
+                    continue
+                for forms in surface_forms_values.values():
+                    match = self.surface_forms_match(sys_line, forms)
+                    if match:
+                        self.log_additional_slot_error(match, surface_forms_slot, sys_line_orig, da_line, index)
+                        self.num_additional_slot_value_error += 1
 
-if __name__ == '__main__':
-    
+            # Find additional kids_allowed slot
+            match_kids_slot = self.surface_forms_match(sys_line, self.kids_surface_forms)
+            if match_kids_slot and "kids_allowed" not in attributes:
+                self.log_additional_slot_error(match_kids_slot, "kids_allowed", sys_line_orig, da_line, index)
+                self.num_additional_slot_value_error += 1
 
+        logging.info(f"Total number of DAs: {len(das)}")
+
+        diff_cannot_check = num_total_num_of_slot_values - self.num_valid_slot_values
+        assert self.num_cannot_check_slot_values == diff_cannot_check, "The number of slots we know we cannot check should equal the total number of slots and the number of slots that we correctly handled"
+
+        logging.info(f"Total number of slots: {num_total_num_of_slot_values}")
+        logging.info(f"Slots that we cannot check: {self.num_cannot_check_slot_values}, out of which {num_type_slots} are 'type=restaurant' slots")
+        errors = self.num_missing_slot_value_error+self.num_additional_slot_value_error
+        print("Missing Slot Errors: ", self.num_missing_slot_value_error)
+        print("Additional Slot Errors: ", self.num_additional_slot_value_error)
+        print("Total Slot Errors: ", errors)
+        print("Number of slots checked: ", self.num_valid_slot_values)
+        if self.num_valid_slot_values:
+            SER = errors / self.num_valid_slot_values
+        else:
+            logging.warning(f"Didn't find any valid slots")
+            SER = 0
+
+        print("SER:", SER)
+
+def main():
     ap = ArgumentParser(description='Slot Error Rate evaluation for Czech restaurant information dataset')
     ap.add_argument('surface_forms_file', type=str, help='JSON file containing the surface forms for all slot values.')
     ap.add_argument('ref_file', type=str, help='References CSV file containing the dialogue acts (DAs) in the first column.')
-    ap.add_argument('--sys_file', type=str, help='System output file to evaluate (text file with one output per line).')
+    ap.add_argument('--sys_file', type=str, help='System output file to evaluate (text file with one output per line). '+
+                    'If not supplied we use the reference realizations from the ref_file as the system output. '+
+                    '(useful for testing and finding mistakes in the dataset)')
     ap.add_argument('-v', '--verbosity', action="count", help="increase output verbosity (e.g., -vv is more than -v)")
     args = ap.parse_args()
 
@@ -406,4 +453,8 @@ if __name__ == '__main__':
 
     surface_forms, das, sys = load_data(args.surface_forms_file, args.ref_file, args.sys_file)
 
-    evaluate(surface_forms, das, sys)
+    ser = Evaluator(surface_forms)
+    ser.evaluate(das, sys)
+
+if __name__ == '__main__':
+    main()

--- a/measure_slot_error_rate.py
+++ b/measure_slot_error_rate.py
@@ -419,18 +419,14 @@ class Evaluator:
 
         logging.info(f"Total number of slots: {num_total_num_of_slot_values}")
         logging.info(f"Slots that we cannot check: {self.num_cannot_check_slot_values}, out of which {num_type_slots} are 'type=restaurant' slots")
-        errors = self.num_missing_slot_value_error+self.num_additional_slot_value_error
-        print("Missing Slot Errors: ", self.num_missing_slot_value_error)
-        print("Additional Slot Errors: ", self.num_additional_slot_value_error)
-        print("Total Slot Errors: ", errors)
-        print("Number of slots checked: ", self.num_valid_slot_values)
-        if self.num_valid_slot_values:
-            SER = errors / self.num_valid_slot_values
+        slot_errors = self.num_missing_slot_value_error+self.num_additional_slot_value_error
+        if num_total_num_of_slot_values:
+            SER = slot_errors / num_total_num_of_slot_values
         else:
             logging.warning(f"Didn't find any valid slots")
             SER = 0
 
-        print("SER:", SER)
+        return SER, slot_errors, self.num_missing_slot_value_error, self.num_additional_slot_value_error
 
 def main():
     ap = ArgumentParser(description='Slot Error Rate evaluation for Czech restaurant information dataset')
@@ -454,7 +450,12 @@ def main():
     surface_forms, das, sys = load_data(args.surface_forms_file, args.ref_file, args.sys_file)
 
     ser = Evaluator(surface_forms)
-    ser.evaluate(das, sys)
+    ser_score, slot_errors, num_missing_slot_value_error, num_additional_slot_value_error = ser.evaluate(das, sys)
+
+    print("Missing Slot Errors: ", num_missing_slot_value_error)
+    print("Additional Slot Errors: ", num_additional_slot_value_error)
+    print("Total Slot Errors: ", slot_errors)
+    print("SER:", ser_score)
 
 if __name__ == '__main__':
     main()

--- a/measure_slot_error_rate.py
+++ b/measure_slot_error_rate.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from argparse import ArgumentParser
+import csv
+import os
+import json
+import re
+import logging
+
+def read_lines(txt_file):
+    with open(txt_file, newline='') as txtfile:
+        return [line.rstrip() for line in txtfile.readlines()]
+
+def read_json(json_file):
+    with open(json_file) as json_file:
+        data = json.load(json_file)
+        return data
+
+def read_csv(csv_file):
+    with open(csv_file, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        fields = list(reader)
+        return fields
+
+def load_data(surface_forms_file, ref_file, sys_file):
+    surface_forms = read_json(surface_forms_file)
+
+    ref_file_ext = os.path.splitext(ref_file)[1]
+    if ref_file_ext == ".csv":
+        ref = read_csv(ref_file)
+    elif ref_file_ext == ".json":
+        ref = read_json(ref_file)
+
+    das = [row["da"] for row in ref]
+
+    if sys_file:
+        sys = read_lines(sys_file)
+    else:
+        sys = [row["text"] for row in ref]
+
+    assert len(sys) == len(das), "Number of references and system outputs must match"
+    return surface_forms, das, sys
+
+def parse_da(da):
+    '''
+    Parses one line of Dialogue Act in the form of "DA_TYPE(SLOT=VALUE,...)".
+    '''
+
+    # Each DA string has exactly one set of parentheses,
+    # they contain the attributes of the da_type (or contain nothing)
+    da_type, attributes_string = da[:-1].split("(")
+    
+    if attributes_string != "":
+        # Commas separate the attributes, no attribute value contain the comma inside the string
+        splitted_attributes = attributes_string.split(",")
+    else:
+        # We have DAs that do not contain any attributes
+        splitted_attributes = []
+    
+    # We store the attributes inside dictionary, slots are unordered.
+    # For some DAs the slots repeat 2 times, we therefore store 
+    # two values for these cases and keep the slots as unique keys
+    parsed_attributes = {}
+    for attr_string in splitted_attributes:
+        # Start with parsing the splitted attributes string
+
+        # Separated attributes contain either a slot constant or a slot with one value.
+        # Slot and its value are separated by "="
+        split_attr = attr_string.split("=")
+        slot = split_attr[0]
+        num_values = len(split_attr) - 1
+        if num_values == 0:
+            parsed_attributes[slot] = []
+        elif num_values == 1:
+            value = split_attr[1]
+            # value may contain apostrophes around the string
+            # it never contains more than these two.
+            value = value.replace("'", "")
+
+            # the value string may contain two actual values separated by " or "
+            if " or " in value:
+                parsed_attributes[slot] = value.split(" or ")
+            else:
+                # if the slot already exists, we add the new value
+                if slot in parsed_attributes:
+                    parsed_attributes[slot].append(value)
+                else:
+                    parsed_attributes[slot] = [value]
+
+    return {
+        "type": da_type,
+        "attributes": parsed_attributes
+    }
+
+def test_parse_da():
+    da = "inform(abc=123)"
+    parsed = parse_da(da)
+    
+    assert parsed == {
+        "type": "inform",
+        "attributes": {"abc" : ["123"]}
+    }
+    da = "inform()"
+    parsed = parse_da(da)
+    assert parsed == {
+        "type": "inform",
+        "attributes": {}
+    }
+    da = "?request(rr='Baráčnická Rychta',rr=dont_care,cc=382)"
+    parsed = parse_da(da)
+    assert parsed == {
+        "type": "?request",
+        "attributes": {"rr": ["Baráčnická Rychta", "dont_care"], "cc": ["382"]}
+    }
+test_parse_da()
+
+def evaluate(surface_forms, das, sys):
+    def capitalize_first_letters(name_list):
+        return [name.title() for name in name_list]
+
+    def find_surface_form(sentence, forms):
+        # We look for some variations in capitalization
+        forms = set(forms + capitalize_first_letters(forms))
+        # We try to match the longest subsequences first
+        forms = sorted(forms, key=len, reverse=True)
+
+        for form in forms:
+            i = sentence.find(form)
+            if i >= 0:
+                return sentence[i:i+len(form)]
+            else:
+                # Try to find the form in uncapitalized sentence
+                uncapitalized_sentence = sentence[0].lower() + sentence[1:]
+                j = uncapitalized_sentence.find(form)
+                if j >= 0:
+                    return sentence[j:j+len(form)]
+
+        return False
+
+    def exact_match(sentence, value):
+        value = str(value)
+        if value in sentence:
+            return value
+        else:
+            return False
+    
+    def regex_match(sentence, regex):
+        matches = re.search(regex, sentence, re.IGNORECASE)
+        if matches:
+            return matches.group(0)
+        else:
+            return False
+    
+    def remove_from_sentence(sentence, value):
+        new_sentence = "".join(sentence.split(value))
+        # Replace multiple spaces with one
+        new_sentence = re.sub(' +',' ',new_sentence)
+        assert new_sentence != sentence, f"didn't find match for value {value} in sentence {sentence}"
+        return new_sentence
+    
+    def match_address(street_value, sentence, forms):
+        street_name, street_num = street_value.rsplit(" ", 1)
+        if street_name in forms:
+            for test_name in forms[street_name]:
+                test_address = f"{test_name} {street_num}"
+                if test_address in sentence:
+                    return test_address
+        return False
+    
+    # def find_kids_negation(sys_line):
+    #     match = regex_match(sys_line, r"\bne\w* (\w+ ){0,5}dět\w*")
+    #     if not match:
+    #         match = regex_match(sys_line, r"dět\w* (\w+ ){0,2}ne\w+")
+    #     if not match:
+    #         match = regex_match(sys_line, r"(zakáz\w*|zákaz\w*) (\w+ ){0,5}dět\w*")
+    #     if not match:
+    #         match = regex_match(sys_line, r"dět\w* (\w+ ){0,5}(zakáz\w*|zákaz\w*)")
+    #     if not match:
+    #         match = regex_match(sys_line, r"bez (\w+ ){0,3}dět\w*")
+    #     return match
+    
+    def validate_slot_match(sys_line, sys_line_orig, match, value, slot, num_valid_slots_with_value, num_missing_slot_value_error):
+        num_valid_slots_with_value += 1
+        if match:
+            sys_line = remove_from_sentence(sys_line, match)
+        else:
+            num_missing_slot_value_error += 1
+            logging.info(f"Slot Error: didn't find match for '{value}' for slot '{slot}' in sentence '{sys_line_orig}'")
+
+        return sys_line, num_valid_slots_with_value, num_missing_slot_value_error
+
+    surface_forms = {slot: {lemma: [form.split("\t")[1] for form in forms] for lemma, forms in values.items()} for slot, values in surface_forms.items()}
+    # print(surface_forms)
+    problems = 0
+    num_valid_slots_with_value = 0
+    num_missing_slot_value_error = 0
+    num_additional_slot_value_error = 0
+
+    for da_string, sys_line_orig in list(zip(das, sys)):
+        sys_line = sys_line_orig
+        da = parse_da(da_string)
+        attributes = da["attributes"]
+
+        # if "kids_allowed" in attributes:
+        #     pass
+        #     # logging.debug(f"{da_string} -> {sys_line}")
+        # else:
+        #     continue
+
+        # num_slots_with_value = sum(1 if value else 0 for _, value in da["attributes"].items())
+
+        # Find the slots that are supposed to be in the system output
+        attribute_priorities = {
+            "kids_allowed": 10
+        }
+        attribute_list = [(slot, values, attribute_priorities[slot] if slot in attribute_priorities else 99) for slot, values in attributes.items()]
+        attribute_list = sorted(attribute_list, key=lambda x: x[2])
+        for slot, values, _ in attribute_list:
+            if slot == "type":
+                continue
+            elif slot == "kids_allowed":
+                logging.debug(f"We cannot handle the slot kids_allowed yet")
+                continue
+                # num_valid_slots_with_value += 1
+
+                # # the sentence needs to contain the word kids
+                # match_kids_slot = find_surface_form(sys_line, ["děti", "dětí", "dětem", "dětmi"])
+                # if not match_kids_slot:
+                #     num_missing_slot_value_error += 1
+                #     logging.info(f"Slot Error: didn't find match for 'děti' for slot '{slot}' in sentence '{sys_line_orig}'")
+                #     continue
+
+                # # For two examples in the train set the value is missing but =yes is assumed
+                # if len(values) == 0:
+                #     values = ["yes"]
+
+                # if len(values) == 1:
+                #     value = values[0]
+                #     if value == "yes":
+                #         match = find_kids_negation(sys_line)
+                #         if match:
+                #             logging.debug(f"!!! '{match}'\t'{sys_line}'\t{da_string}")
+                #     elif value == "no":
+                #         match = find_kids_negation(sys_line)
+                #         if not match:
+                #             logging.debug(f"'{match}'\t'{sys_line}'\t{da_string}")
+                #     elif value == "dont_care":
+                #         logging.debug(f"We cannot handle kids_allowed='dont_care' yet")
+                #     elif value == "none":
+                #         logging.debug(f"We cannot handle kids_allowed='none' yet")
+                #     else:
+                #         assert False, f"Invalid value {value} for kids_allowed"
+
+                # if len(values) == 2:
+                #     if set(values) == {"yes", "no"}:
+                #         logging.debug(f"We cannot handle kids_allowed='yes or no' yet")
+                #     elif set(values) == {"dont_care", "yes"}:
+                #         logging.debug(f"We cannot handle kids_allowed='yes or no' yet")
+                #     else:
+                #         assert False, f"Invalid value {values} for kids_allowed"
+            elif slot in ["phone", "count", "postcode"]:
+                for value in values:
+                    match = exact_match(sys_line, value)
+                    sys_line, num_valid_slots_with_value, num_missing_slot_value_error = validate_slot_match(sys_line, sys_line_orig, match, value, slot, num_valid_slots_with_value, num_missing_slot_value_error)
+            elif slot == "address":
+                for value in values:
+                    match = match_address(value, sys_line, surface_forms["street"])
+                    sys_line, num_valid_slots_with_value, num_missing_slot_value_error = validate_slot_match(sys_line, sys_line_orig, match, value, slot, num_valid_slots_with_value, num_missing_slot_value_error)
+            elif slot == "price":
+                for value in values:
+                    if "between" in value:
+                        # remove text around prices
+                        value = value[8:-3]
+                        price1, price2 = value.split(" and ")
+                        match = False
+                        for form in surface_forms["price"]["between _ and _ Kč"]:
+                            form = form.split("_")
+                            assert len(form) == 3
+                            czech_between_string = form[0] + price1 + form[1] + price2 + form[2]
+                            match = exact_match(sys_line, czech_between_string)
+                            if match:
+                                break
+                    else:
+                        match = exact_match(sys_line, value)
+                    
+                    sys_line, num_valid_slots_with_value, num_missing_slot_value_error = validate_slot_match(sys_line, sys_line_orig, match, value, slot, num_valid_slots_with_value, num_missing_slot_value_error)
+            elif slot in surface_forms:
+                for value in values:
+                    if value in surface_forms[slot]:
+                        match = find_surface_form(sys_line, surface_forms[slot][value])
+                        sys_line, num_valid_slots_with_value, num_missing_slot_value_error = validate_slot_match(sys_line, sys_line_orig, match, value, slot, num_valid_slots_with_value, num_missing_slot_value_error)
+                    else:
+                        # TODO: handle dont_care
+                        # if value == "dont_care":
+                        #     problems += 1
+                        #     continue
+                        #
+                        logging.debug(f"Coverage problem: non-existing value '{value}' for slot {slot}")
+            else:
+                logging.error(f"Invalid slot in the parsed attributes of DA '{da_string}': {slot}")
+                pass
+        
+        
+        # Find additional slot values that are not supposed to be in the system output
+        for surface_forms_slot in surface_forms:
+
+            # Do not check those slots that are inside the DA without any value
+            # These often list some or all of the value keywords to raise a question to the user
+            if surface_forms_slot in attributes and attributes[surface_forms_slot] == []:
+                continue
+
+            if surface_forms_slot == "price_range":
+                continue
+            for forms in surface_forms[surface_forms_slot].values():
+                match = find_surface_form(sys_line, forms)
+                if match:
+                    logging.info(f"Slot Error: found additional value '{match}' for slot '{surface_forms_slot}' in sentence '{sys_line_orig}'. DA is '{da_string}'")
+                    num_additional_slot_value_error += 1
+                    # print(sys_line, forms)
+
+        # Find additional kids_allowed slot
+        # TODO: activate
+        # match_kids_slot = find_surface_form(sys_line, ["děti", "dětí", "dětem", "dětmi"])
+        # if match_kids_slot:
+        #     num_additional_slot_value_error += 1
+        #     logging.info(f"Slot Error: found additional value '{match_kids_slot}' for slot 'kids_allowed' in sentence '{sys_line_orig}'. DA is '{da_string}'")
+
+    print("total number of DAs", len(das))
+    print("problems", problems)
+    print("valid slots", num_valid_slots_with_value)
+    if num_valid_slots_with_value:
+        SER = (num_missing_slot_value_error+num_additional_slot_value_error) / num_valid_slots_with_value
+        print("SER", SER)
+    else:
+        logging.warning(f"Didn't find any valid slots")
+        print("SER", 0)
+
+
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.DEBUG)
+
+    ap = ArgumentParser(description='Slot Error Rate evaluation for Czech restaurant information dataset')
+    ap.add_argument('surface_forms_file', type=str, help='JSON file containing the surface forms for all slot values.')
+    ap.add_argument('ref_file', type=str, help='References CSV file containing the dialogue acts (DAs) in the first column.')
+    ap.add_argument('--sys_file', type=str, help='System output file to evaluate (text file with one output per line).')
+    args = ap.parse_args()
+
+    surface_forms, das, sys = load_data(args.surface_forms_file, args.ref_file, args.sys_file)
+
+    evaluate(surface_forms, das, sys)

--- a/measure_slot_error_rate.py
+++ b/measure_slot_error_rate.py
@@ -276,13 +276,6 @@ def evaluate(surface_forms, das, sys):
                         logging.debug(f"Coverage problem: We cannot handle kids_allowed='yes',kids_allowed='dont_care'")
                     else:
                         assert False, f"Invalid value {values} for kids_allowed"
-                
-                # Warning, this is maybe dangerous - but we remove all matched "děti" string
-                while match_kids_slot:
-                    sys_line = remove_from_sentence(sys_line, match_kids_slot)
-                    match_kids_slot = surface_forms_match(sys_line, ["děti", "dětí", "dětem", "dětmi"])
-                # This is because we don't want to trigger the "additional slot" error 
-                # for the slot values we cannot handle
 
             elif slot in ["phone", "count", "postcode"]:
                 # TODO: For count we might want to implement checking numerals (such as "dvě", "tři", ...)
@@ -357,6 +350,7 @@ def evaluate(surface_forms, das, sys):
 
         # Find additional kids_allowed slot
         match_kids_slot = surface_forms_match(sys_line, ["děti", "dětí", "dětem", "dětmi"])
+        if match_kids_slot and "kids_allowed" not in attributes:
             log_additional_slot_error(match_kids_slot, "kids_allowed", sys_line_orig, da_line, index)
             num_additional_slot_value_error += 1
 

--- a/test_measure_slot_error_rate.py
+++ b/test_measure_slot_error_rate.py
@@ -1,0 +1,96 @@
+from measure_slot_error_rate import parse_da, Evaluator, logging
+
+def test_parse_da():
+    da = "inform(abc=123)"
+    parsed = parse_da(da)
+    
+    assert parsed == {
+        "type": "inform",
+        "attributes": {"abc" : ["123"]}
+    }
+    da = "inform()"
+    parsed = parse_da(da)
+    assert parsed == {
+        "type": "inform",
+        "attributes": {}
+    }
+    da = "?request(rr='Baráčnická Rychta',rr=dont_care,cc=382)"
+    parsed = parse_da(da)
+    assert parsed == {
+        "type": "?request",
+        "attributes": {"rr": ["Baráčnická Rychta", "dont_care"], "cc": ["382"]}
+    }
+
+def test_evaluator_name():
+    surface_forms = {
+        "name": {
+            "Restaurace A": [
+                "Restaurace A\tRestaurace A",
+                "Restaurace A\tRestauraci A"
+            ],
+            "Restaurace B": [
+                "Restaurace B\tRestaurace B",
+                "Restaurace B\tRestauraci B"
+            ],
+        }
+    }
+    ser = Evaluator(surface_forms)
+
+    # Correct output
+    error_rate, errs, miss, add = ser.evaluate(["inform(name='Restaurace A')"], ["Našla jsem Restauraci A"])
+    assert error_rate == 0
+    # Missing error
+    error_rate, errs, miss, add = ser.evaluate(["inform(name='Restaurace A')"], ["Našla jsem Restauraci"])
+    assert error_rate == 1 and miss == 1 and add == 0
+    # Additional error
+    error_rate, errs, miss, add = ser.evaluate(["inform(type=restaurant)"], ["Našla jsem Restauraci B"])
+    assert error_rate == 1 and miss == 0 and add == 1
+    # Additional error with the same slot
+    error_rate, errs, miss, add = ser.evaluate(["inform(name='Restaurace A')"], ["Našla jsem Restauraci A a Restauraci B"])
+    assert error_rate == 1 and miss == 0 and add == 1
+    # Repetition doesn't count as an error
+    error_rate, errs, miss, add = ser.evaluate(["inform(name='Restaurace B')"], ["Našla jsem Restauraci B a Restauraci B"])
+    assert error_rate == 0 and miss == 0 and add == 0
+    # Additional+Missing error
+    error_rate, errs, miss, add = ser.evaluate(["inform(name='Restaurace B')"], ["Našla jsem Restauraci A"])
+    assert error_rate == 2 and miss == 1 and add == 1
+
+def test_evaluator_kids_allowed():
+    surface_forms = {}
+    ser = Evaluator(surface_forms)
+
+    # Correct output
+    error_rate, errs, miss, add = ser.evaluate(["inform(kids_allowed=no)"], ["Restaurace není vhodná pro děti"])
+    assert error_rate == 0
+    # Correct output
+    error_rate, errs, miss, add = ser.evaluate(["inform(kids_allowed=yes)"], ["Restaurace je vhodná pro děti"])
+    assert error_rate == 0
+    # Missing error
+    error_rate, errs, miss, add = ser.evaluate(["inform(kids_allowed=no)"], ["Doporučuji restauraci BarBar"])
+    assert error_rate == 1 and miss == 1 and add == 0
+    # Additional error
+    error_rate, errs, miss, add = ser.evaluate(["inform(type=restaurant)"], ["Restaurace je vhodná pro děti"])
+    assert error_rate == 1 and miss == 0 and add == 1
+    # Additional+Missing error
+    error_rate, errs, miss, add = ser.evaluate(["inform(kids_allowed=no)"], ["Restaurace je vhodná pro děti"])
+    assert error_rate == 2 and miss == 1 and add == 1
+
+    # --- special cases ---
+
+    # Correct output we cannot check
+    error_rate, errs, miss, add = ser.evaluate(["inform(count=12,kids_allowed=dont_care)"], ["V nabídce je 12 restaurací , které nemají požadavky ohledně dětí"])
+    assert error_rate == 0
+    # Incorrect output we cannot check
+    error_rate, errs, miss, add = ser.evaluate(["inform(count=12,kids_allowed=dont_care)"], ["V nabídce je 12 restaurací které jsou vhodné pro děti"])
+    assert error_rate == 0
+    # But we can check some additional errors outside of yes/no value
+    # because we check the presence of the word "dítě"
+    error_rate, errs, miss, add = ser.evaluate(["inform(count=12)"], ["V nabídce je 12 restaurací, které nemají požadavky ohledně dětí"])
+    assert error_rate == 1 and miss == 0 and add == 1
+
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.DEBUG)
+
+    test_parse_da()
+    test_evaluator_name()
+    test_evaluator_kids_allowed()


### PR DESCRIPTION
Evaluation script for computing a model-independent Slot Error Rate. This script is useful for:

- comparing the semantic accuracy of different NLG models.
- finding errors in the dataset.

The script is mostly based on matching the surface forms from the [surface_forms.json](https://github.com/UFAL-DSG/cs_restaurant_dataset/blob/master/surface_forms.json) file. Additionally there are some hard-coded rules to check for more complex cases and slots.

In particular, the script is able to find missing/additional errors for following slots/values: 
- all slots with surface forms in the surface_forms.json file (name, area, food, price, near, postcode, price_range, good_for_meal)
- address slot, using manual rules and surface_forms.json file
- slots with number values (phone, count, postcode)
- values _yes_ and _no_ for the kids_allowed slot
- multiple values per slot (eg. when one slot type occurs twice in the DA or if the slot value contains the "or" keyword).

On the other hand we don't check the following:

- _type_ slot - since it doesn't really affect the output realization
- values _dont_care_ and _none_ for various slots
- slots without a value